### PR TITLE
Issue #20 - Items cannot be added to cart if .NET incorrectly detects browser cookie capability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# Project-specific editor settings
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/Libraries/Hotcakes.Commerce/SessionManager.cs
+++ b/Libraries/Hotcakes.Commerce/SessionManager.cs
@@ -474,11 +474,8 @@ namespace Hotcakes.Commerce
             {
                 if (Factory.HttpContext != null)
                 {
-                    if (Factory.HttpContext.Request.Browser.Cookies)
-                    {
-                        var cookies = Factory.HttpContext.Request.Cookies;
-                        return GetCookieString(cookieName, cookies);
-                    }
+                    var cookies = Factory.HttpContext.Request.Cookies;
+                    return GetCookieString(cookieName, cookies);
                 }
             }
             catch
@@ -533,27 +530,24 @@ namespace Hotcakes.Commerce
 
         public static void SetCookieString(string cookieName, string value, DateTime? expirationDate, bool secure)
         {
-            if (Factory.HttpContext != null)
-            {
-                if (Factory.HttpContext.Request.Browser.Cookies)
-                {
-                    try
-                    {
-                        var saveCookie = new HttpCookie(cookieName, value);
-                        if (expirationDate.HasValue)
-                            saveCookie.Expires = expirationDate.Value;
-                        else
-                            saveCookie.Expires = DateTime.Now.AddYears(50);
-                        saveCookie.Secure = secure;
-                        Factory.HttpContext.Request.Cookies.Remove(cookieName);
-                        Factory.HttpContext.Response.Cookies.Add(saveCookie);
-                    }
-                    catch (Exception Ex)
-                    {
-                        EventLog.LogEvent(Ex);
-                    }
-                }
-            }
+	        if (Factory.HttpContext != null)
+	        {
+		        try
+		        {
+			        var saveCookie = new HttpCookie(cookieName, value);
+			        if (expirationDate.HasValue)
+				        saveCookie.Expires = expirationDate.Value;
+			        else
+				        saveCookie.Expires = DateTime.Now.AddYears(50);
+			        saveCookie.Secure = secure;
+			        Factory.HttpContext.Request.Cookies.Remove(cookieName);
+			        Factory.HttpContext.Response.Cookies.Add(saveCookie);
+		        }
+		        catch (Exception Ex)
+		        {
+			        EventLog.LogEvent(Ex);
+		        }
+	        }
         }
 
         #endregion

--- a/Libraries/Hotcakes.Web/Cookies.cs
+++ b/Libraries/Hotcakes.Web/Cookies.cs
@@ -43,7 +43,7 @@ namespace Hotcakes.Web
                 {
                     if (context.Request != null)
                     {
-                        if (context.Request.Browser.Cookies && context.Request.Cookies.AllKeys.Contains(cookieName))
+                        if (context.Request.Cookies.AllKeys.Contains(cookieName))
                         {
                             var checkCookie = context.Request.Cookies[cookieName];
                             if (checkCookie != null)
@@ -119,29 +119,23 @@ namespace Hotcakes.Web
             {
                 if (context != null)
                 {
-                    if (context.Request != null)
+                    var saveCookie = new HttpCookie(cookieName, value);
+                    if (!temporary)
                     {
-                        if (context.Request.Browser.Cookies)
+                        if (expirationDate.HasValue)
                         {
-                            var saveCookie = new HttpCookie(cookieName, value);
-                            if (!temporary)
-                            {
-                                if (expirationDate.HasValue)
-                                {
-                                    saveCookie.Expires = expirationDate.Value;
-                                }
-                                else
-                                {
-                                    saveCookie.Expires = DateTime.Now.AddYears(50);
-                                }
-                            }
-                            if (domain.Trim().Length > 0)
-                            {
-                                saveCookie.Domain = domain;
-                            }
-                            context.Response.Cookies.Add(saveCookie);
+                            saveCookie.Expires = expirationDate.Value;
+                        }
+                        else
+                        {
+                            saveCookie.Expires = DateTime.Now.AddYears(50);
                         }
                     }
+                    if (domain.Trim().Length > 0)
+                    {
+                        saveCookie.Domain = domain;
+                    }
+                    context.Response.Cookies.Add(saveCookie);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes #20.

Removed unnecessary and potentially damaging browser capability checks. Browsers erroneously detected as not supporting cookies could not retain shopping cart state.