### PR TITLE
Issues/issue 120 - Failed Checkout Returns to Cart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sln.docstates
 *.local.sln
 *.GhostDoc.xml
+._*.*
 
 ## Ignore VS2015/Roslyn artifacts
 *.sln.ide/

--- a/Website/DesktopModules/Hotcakes/Core/Controllers/CheckoutController.PaymentError.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/CheckoutController.PaymentError.cs
@@ -42,11 +42,6 @@ namespace Hotcakes.Modules.Core.Controllers
 		[NonCacheableResponseFilter]
 		public ActionResult PaymentError()
 		{
-			if (CurrentCart == null || CurrentCart.Items == null || CurrentCart.Items.Count == 0)
-			{
-				Response.Redirect(Url.RouteHccUrl(HccRoute.Cart));
-			}
-
 			CheckoutViewModel model = PaymentErrorSetup();
 			if (ValidateSession(model))
 			{


### PR DESCRIPTION
Since the PaymentError action will always be called after the order has been created and the cart cookie has been cleared I have removed the CurrentCart check since it will always return null.