### PR TITLE
CI: CategoryViewer - DrillDown view error when no category is set #101

### DIFF
--- a/Website/DesktopModules/Hotcakes/Core/Controllers/CategoryController.cs
+++ b/Website/DesktopModules/Hotcakes/Core/Controllers/CategoryController.cs
@@ -420,7 +420,7 @@ namespace Hotcakes.Modules.Core.Controllers
             };
 
             var cat = HccApp.CatalogServices.Categories.Find(filter.CategoryId);
-            queryAdv.SortOrder = filter.SortOrder != CategorySortOrder.None ? filter.SortOrder : cat.DisplaySortOrder;
+            queryAdv.SortOrder = filter.SortOrder != CategorySortOrder.None ? filter.SortOrder : cat != null ? cat.DisplaySortOrder : CategorySortOrder.None;
             return queryAdv;
         }
 


### PR DESCRIPTION
I have checked with null reference object.