### PR TITLE
SI: PayPal Express Authorize Setting Not Creating Authorizations #50

### DIFF
--- a/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
+++ b/Libraries/Hotcakes.Commerce/BusinessRules/OrderTasks/StartPaypalExpressCheckout.cs
@@ -63,14 +63,10 @@ namespace Hotcakes.Commerce.BusinessRules.OrderTasks
                     EventLog.LogEvent("PayPal Express Checkout", "CartReturnUrl=" + cartReturnUrl, EventLogSeverity.Information);
 
                     PaymentActionCodeType mode = PaymentActionCodeType.Authorization;
-                    if (context.HccApp.CurrentStore.Settings.PayPal.ExpressAuthorizeOnly)
-					{
-						mode = PaymentActionCodeType.Order;
-					}
-                    else
+                    if (!context.HccApp.CurrentStore.Settings.PayPal.ExpressAuthorizeOnly)
 					{
                         mode = PaymentActionCodeType.Sale;
-					}
+                    }
 
                     // Accelerated boarding
                     if (string.IsNullOrWhiteSpace(context.HccApp.CurrentStore.Settings.PayPal.UserName))

--- a/Libraries/Hotcakes.Commerce/Payment/Methods/PaypalExpress.cs
+++ b/Libraries/Hotcakes.Commerce/Payment/Methods/PaypalExpress.cs
@@ -70,10 +70,16 @@ namespace Hotcakes.Commerce.Payment.Methods
                 {
                     var OrderNumber = t.MerchantInvoiceNumber + Guid.NewGuid();
 
+                    PaymentActionCodeType mode = PaymentActionCodeType.Authorization;
+                    if (!app.CurrentStore.Settings.PayPal.ExpressAuthorizeOnly)
+                    {
+                        mode = PaymentActionCodeType.Sale;
+                    }
+
                     var paymentResponse = ppAPI.DoExpressCheckoutPayment(t.PreviousTransactionNumber,
                         t.PreviousTransactionAuthCode,
                         t.Amount.ToString("N", CultureInfo.InvariantCulture),
-                        PaymentActionCodeType.Order,
+                        mode,
                         PayPalAPI.GetCurrencyCodeType(app.CurrentStore.Settings.PayPal.Currency),
                         OrderNumber);
 


### PR DESCRIPTION
To fulfill this requirements two major changes are done in two files , which are as below
1. StartPaypalExpressCheckout.cs
2. PaypalExpress.cs 
 in these files an condition is included to verify "Authorization" or "Sale" option from Paypal Express Settings.